### PR TITLE
Fix conflict with registry-rebuild

### DIFF
--- a/islandora_attach_datastream.drush.inc
+++ b/islandora_attach_datastream.drush.inc
@@ -7,7 +7,7 @@
 /**
  * Implements hook_drush_help().
  */
-function registry_rebuild_drush_help($section) {
+function islandora_attach_datastream_drush_help($section) {
   switch ($section) {
     case 'drush:islandora_attach_datastream_to_object':
       return dt('Attaches a datastream via Islandora to a Fedora object.');


### PR DESCRIPTION
# Problem / motivation

If you have [the registry rebuild module](https://www.drupal.org/project/registry_rebuild) installed at `$HOME/.drush/registry_rebuild` and this module installed on a site, trying to rebuild the registry for that site results in an error:

```
$ drush -y rr

Fatal error: Cannot redeclare registry_rebuild_drush_help() (previously declared in $HOME/.drush/registry_rebuild/registry_rebuild.drush.inc:16) in /path/to/webroot/sites/default/modules/islandora_attach_datastream/islandora_attach_datastream.drush.inc on line 10

Call Stack:
    0.0004     231920   1. {main}() $HOME/.composer/global/drush/drush/vendor/drush/drush/drush.php:0
    0.0050     234752   2. drush_main() $HOME/.composer/global/drush/drush/vendor/drush/drush/drush.php:12
    0.9079    4056696   3. Drush\Boot\BaseBoot->bootstrap_and_dispatch() $HOME/.composer/global/drush/drush/vendor/drush/drush/includes/preflight.inc:66
    0.9137    4066736   4. drush_dispatch() $HOME/.composer/global/drush/drush/vendor/drush/drush/lib/Drush/Boot/BaseBoot.php:67
    0.9166    4073480   5. call_user_func_array:{$HOME/.composer/global/drush/drush/vendor/drush/drush/includes/command.inc:199}() $HOME/.composer/global/drush/drush/vendor/drush/drush/includes/command.inc:199
    0.9166    4073760   6. drush_command() $HOME/.composer/global/drush/drush/vendor/drush/drush/includes/command.inc:199
    0.9171    4078608   7. _drush_invoke_hooks() $HOME/.composer/global/drush/drush/vendor/drush/drush/includes/command.inc:231
    0.9284    4201272   8. call_user_func_array:{$HOME/.composer/global/drush/drush/vendor/drush/drush/includes/command.inc:422}() $HOME/.composer/global/drush/drush/vendor/drush/drush/includes/command.inc:422
    0.9284    4201840   9. drush_registry_rebuild() $HOME/.composer/global/drush/drush/vendor/drush/drush/includes/command.inc:422
    0.9284    4202008  10. drush_bootstrap_to_phase() $HOME/.drush/registry_rebuild/registry_rebuild.drush.inc:55
    1.2563    1416360  11. drush_bootstrap() $HOME/.composer/global/drush/drush/vendor/drush/drush/includes/bootstrap.inc:473
    1.2627    1420464  12. _drush_find_commandfiles() $HOME/.composer/global/drush/drush/vendor/drush/drush/includes/bootstrap.inc:358
    1.2633    1424200  13. _drush_add_commandfiles() $HOME/.composer/global/drush/drush/vendor/drush/drush/includes/command.inc:1583
    1.7048    1486424  14. Drush\Command\Commandfiles->add() $HOME/.composer/global/drush/drush/vendor/drush/drush/includes/command.inc:1646

Drush command terminated abnormally due to an unrecoverable error.                                                                         [error]
Error: Cannot redeclare registry_rebuild_drush_help() (previously declared in
$HOME/.drush/registry_rebuild/registry_rebuild.drush.inc:16) in
/path/to/webroot/sites/default/modules/islandora_attach_datastream/islandora_attach_datastream.drush.inc, line 10
```

This happens because this module's implementation of `hook_drush_help()` is named `registry_rebuild_drush_help()`; that is to say, the same name as the registry rebuild module's implementation of `hook_drush_help()`. This may have occurred from copy-pasted code.

# Proposed resolution

Rename this module's implementation of `hook_drush_help()` from `registry_rebuild_drush_help` to `islandora_attach_datastream_drush_help()`.

# Remaining tasks

- [ ] Code review
- [ ] Commit

# User interface changes

None.

# API changes

None.

# Data model changes

None.